### PR TITLE
Change made to post build command

### DIFF
--- a/BeefProj.toml
+++ b/BeefProj.toml
@@ -11,71 +11,77 @@ ProductVersion = "0.0.1"
 
 [Configs.Debug.Win64]
 BeefLibType = "Static"
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
 [Configs.Debug.Win32]
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
-[Configs.Release.Win64]
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
+[Configs.Debug_add.Win64]
+BeefLibType = "Static"
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
+DebugCommandArguments = "add steak.logging --debug"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
-[Configs.Release.Win32]
+[Configs.Debug_add.Win32]
+BeefLibType = "Static"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
+[Configs.Debug_help.Win64]
+BeefLibType = "Static"
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
+DebugCommandArguments = "--help"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
+[Configs.Debug_help.Win32]
+BeefLibType = "Static"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
+[Configs.Debug_init.Win64]
+BeefLibType = "Static"
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
+DebugCommandArguments = "init"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS", "DEBUG"]
+
+[Configs.Debug_init.Win32]
+BeefLibType = "Static"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
+[Configs.Debug_install.Win64]
+BeefLibType = "Static"
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
+DebugCommandArguments = "install mypackage --debug"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS", "DEBUG"]
+
+[Configs.Debug_install.Win32]
+BeefLibType = "Static"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
 [Configs.Paranoid.Win64]
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
 [Configs.Paranoid.Win32]
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
+[Configs.Release.Win64]
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
+[Configs.Release.Win32]
+PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
+
 [Configs.Test.Win64]
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
+PostBuildCmds = ["xcopy $(TargetDir)\\$(ProjectName).exe $(ProjectDir)\\bin /y"]
+DebugCommand = "$(ProjectDir)\\bin\\$(ProjectName).exe"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
 
 [Configs.Test.Win32]
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
-
-[Configs."grill add".Win64]
-BeefLibType = "Static"
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
-DebugCommandArguments = "add steak.logging -debug"
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
-
-[Configs."grill add".Win32]
-BeefLibType = "Static"
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
-
-[Configs."grill install".Win64]
-BeefLibType = "Static"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["if not exist \"$(TargetDir)/Git\" ( xcopy \"$(ProjectDir)\\bin\" \"$(TargetDir)\" /e /c /i /q /y )", "del /F/Q/S \"$(TargetDir)/Packages\" >NUL"]
-DebugCommandArguments = "install mypackage --debug"
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS", "DEBUG"]
-
-[Configs."grill install".Win32]
-BeefLibType = "Static"
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
-
-[Configs."grill --help".Win64]
-BeefLibType = "Static"
-BuildCommandsOnCompile = "Never"
-BuildCommandsOnRun = "Never"
-PostBuildCmds = ["xcopy \"$(ProjectDir)/bin\" \"$(TargetDir)\" /e /c /i /q /y"]
-PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]
-
-[Configs."grill --help".Win32]
-BeefLibType = "Static"
 PreprocessorMacros = ["GRILL_PLATFORM_WINDOWS"]


### PR DESCRIPTION
Post build commands now copy the generated binary inside the bin folder alongside the Git folder. Execution of the configuration runs Grill from the bin folder.